### PR TITLE
Add another lighting service (Razer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Visual Studio Code
+.vscode

--- a/OnlineStatusLight.Application.Razer/OnlineStatusLight.Application.Razer.csproj
+++ b/OnlineStatusLight.Application.Razer/OnlineStatusLight.Application.Razer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Colore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OnlineStatusLight.Core\OnlineStatusLight.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/OnlineStatusLight.Application.Razer/RazerLightService.cs
+++ b/OnlineStatusLight.Application.Razer/RazerLightService.cs
@@ -1,0 +1,70 @@
+﻿using Colore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using OnlineStatusLight.Core.Models;
+using OnlineStatusLight.Core.Services;
+
+namespace OnlineStatusLight.Application.Razer
+{
+    public class RazerLightService : ILightService
+    {
+        private ILogger<RazerLightService> _logger;
+        private bool _headSetOnly;
+        private IChroma? _chroma;
+
+        public RazerLightService(IConfiguration configuration, ILogger<RazerLightService> logger)
+        {
+            _logger = logger;
+            _headSetOnly = bool.TryParse(configuration["razer:headsetonly"], out var headSetOnly) ? headSetOnly : false;
+        }
+        public async void End()
+        {
+            _logger.LogInformation("End RazerLightService");
+            if(_chroma != null) {
+                await _chroma.UninitializeAsync();
+            }
+        }
+
+        public async Task SetState(MicrosoftTeamsStatus status)
+        {
+            switch (status)
+            {
+                case MicrosoftTeamsStatus.Available:
+                    await SetTargetedDeviceColor(Colore.Data.Color.Green);
+                    break;
+                case MicrosoftTeamsStatus.Away:
+                    await SetTargetedDeviceColor(Colore.Data.Color.Yellow);
+                    break;
+                case MicrosoftTeamsStatus.OutOfOffice:
+                    await SetTargetedDeviceColor(Colore.Data.Color.Purple);
+                    break;
+                case MicrosoftTeamsStatus.Busy:
+                case MicrosoftTeamsStatus.DoNotDisturb:
+                    await SetTargetedDeviceColor(Colore.Data.Color.Red);
+                    break;
+                default:
+                    _logger.LogInformation($"Received: {status}. Setting color to off...");
+                    await SetTargetedDeviceColor(Colore.Data.Color.Black);
+                    break;
+            }
+        }
+
+        private async Task SetTargetedDeviceColor(Colore.Data.Color color) 
+        {
+            if(_chroma != null) 
+            {
+                if(_headSetOnly) {
+                    await _chroma.Headset.SetStaticAsync(color);
+                } else {
+                    await _chroma.SetAllAsync(color);
+                }
+            }
+        }
+
+        public async void Start()
+        {
+            _logger.LogInformation("Start RazerLightService");
+            _chroma = await ColoreProvider.CreateNativeAsync();
+        }
+    }
+}

--- a/OnlineStatusLight.Application/MicrosoftTeamsService.cs
+++ b/OnlineStatusLight.Application/MicrosoftTeamsService.cs
@@ -8,19 +8,19 @@ namespace OnlineStatusLight.Application
 {
     public class MicrosoftTeamsService : IMicrosoftTeamsService
     {
-        private readonly ILogger<SonoffBasicR3Service> _logger;
+        private readonly ILogger<MicrosoftTeamsService> _logger;
         private MicrosoftTeamsStatus _lastStatus = MicrosoftTeamsStatus.Unknown;
         private DateTime _fileLastUpdated = DateTime.MinValue;
 
         public int PoolingInterval { get; set; }
         public string LogsFilePath { get; set; }
 
-        public MicrosoftTeamsService(IConfiguration configuration, ILogger<SonoffBasicR3Service> logger)
+        public MicrosoftTeamsService(IConfiguration configuration, ILogger<MicrosoftTeamsService> logger)
         {
             _logger = logger;
 
             this.PoolingInterval = Convert.ToInt32(configuration["msteams:interval"]);
-            this.LogsFilePath = Convert.ToString(configuration["msteams:logfile"]);
+            this.LogsFilePath = Environment.ExpandEnvironmentVariables(Convert.ToString(configuration["msteams:logfile"]));
         }
 
         public MicrosoftTeamsStatus GetCurrentStatus()

--- a/OnlineStatusLight.Application/SonoffBasicR3Service.cs
+++ b/OnlineStatusLight.Application/SonoffBasicR3Service.cs
@@ -5,7 +5,7 @@ using OnlineStatusLight.Core.Services;
 
 namespace OnlineStatusLight.Application
 {
-    public class SonoffBasicR3Service : ISonoffBasicR3Service
+    public class SonoffBasicR3Service : ISonoffBasicR3Service, ILightService
     {
         private readonly ILogger<SonoffBasicR3Service> _logger;
 
@@ -120,6 +120,37 @@ namespace OnlineStatusLight.Application
                 Leds[led].DeviceId = conf.Data.DeviceId;
                 // Leds[led].Status = conf.Data.Switch == "on" ? SonoffLedStatus.On: SonoffLedStatus.Off;
             }
+        }
+
+        public async Task SetState(MicrosoftTeamsStatus status)
+        {
+            switch (status)
+            {
+                case MicrosoftTeamsStatus.Available:
+                    await SwitchOn(SonoffLedType.Green);
+                    break;
+                case MicrosoftTeamsStatus.Busy:
+                    await SwitchOn(SonoffLedType.Red);
+                    break;
+                case MicrosoftTeamsStatus.DoNotDisturb:
+                    await SwitchOn(SonoffLedType.Red, false);
+                    await SwitchOn(SonoffLedType.Green, false);
+                    break;
+                default:
+                    await SwitchOffAll();
+                    break;
+            }
+        }
+
+        public void Start()
+        {
+            _logger.LogInformation($"Starting SonoffBasicR3Service");
+        }
+
+        public void End()
+        {
+             _logger.LogInformation($"Ending SonoffBasicR3Service");
+            SwitchOffAll().GetAwaiter().GetResult();
         }
     }
 }

--- a/OnlineStatusLight.Core/Services/ILightService.cs
+++ b/OnlineStatusLight.Core/Services/ILightService.cs
@@ -1,0 +1,11 @@
+using OnlineStatusLight.Core.Models;
+
+namespace OnlineStatusLight.Core.Services
+{
+    public interface ILightService
+    {
+        void Start();
+        void End();
+        Task SetState(MicrosoftTeamsStatus status);
+    }
+}

--- a/OnlineStatusLight.Forms/OnlineStatusLight.Forms.csproj
+++ b/OnlineStatusLight.Forms/OnlineStatusLight.Forms.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OnlineStatusLight.Application\OnlineStatusLight.Application.csproj" />
+    <ProjectReference Include="..\OnlineStatusLight.Application.Razer\OnlineStatusLight.Application.Razer.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OnlineStatusLight.Forms/Startup.cs
+++ b/OnlineStatusLight.Forms/Startup.cs
@@ -25,10 +25,11 @@ namespace OnlineStatusLight.Forms
                         .AddJsonFile(Path.GetFullPath("appsettings.json"), true, true)
                         .Build();
 
+                    var lightService = Type.GetType(ConfigurationRoot!["lightservice"]) ?? typeof(SonoffBasicR3Service);
                     // configure services
                     services
+                        .AddSingleton(typeof(ILightService), lightService)
                         .AddSingleton<IMicrosoftTeamsService, MicrosoftTeamsService>()
-                        .AddSingleton<ISonoffBasicR3Service, SonoffBasicR3Service>()
                         .AddSingleton<SyncLightService>()
                         .AddHostedService<SyncLightService>();
 
@@ -60,6 +61,11 @@ namespace OnlineStatusLight.Forms
 
         public static IServiceCollection ConfigureHttpClients(IServiceCollection services, IConfiguration configuration)
         {
+            if(configuration["sonoff"] == null) 
+            {
+                return services;
+            }
+
             services.AddHttpClient("sonoffRedLedApi", c =>
             {
                 c!.BaseAddress = new Uri($"http://{configuration!["sonoff:red:ip"]}:8081/zeroconf/");

--- a/OnlineStatusLight.Forms/appsettings.json
+++ b/OnlineStatusLight.Forms/appsettings.json
@@ -1,4 +1,8 @@
 {
+  "lightservice": "OnlineStatusLight.Application.Razer.RazerLightService, OnlineStatusLight.Application.Razer",
+  "razer": {
+    "headsetonly": true
+  },
   "sonoff": {
     "red": {
       "ip": "192.168.0.62"
@@ -9,6 +13,6 @@
   },
   "msteams": {
     "interval": 5,
-    "logfile": "C:\\Users\\miscalge\\AppData\\Roaming\\Microsoft\\Teams\\logs.txt"
+    "logfile": "%appdata%\\Microsoft\\Teams\\logs.txt"
   }
 }

--- a/OnlineStatusLight.sln
+++ b/OnlineStatusLight.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OnlineStatusLight.Application.Razer", "OnlineStatusLight.Application.Razer\OnlineStatusLight.Application.Razer.csproj", "{324E0321-A1BB-4CFB-A4AD-0A7EE1878968}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{B49009ED-06B5-4D6A-A34E-2C4F723A44D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B49009ED-06B5-4D6A-A34E-2C4F723A44D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B49009ED-06B5-4D6A-A34E-2C4F723A44D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{324E0321-A1BB-4CFB-A4AD-0A7EE1878968}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{324E0321-A1BB-4CFB-A4AD-0A7EE1878968}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{324E0321-A1BB-4CFB-A4AD-0A7EE1878968}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{324E0321-A1BB-4CFB-A4AD-0A7EE1878968}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,7 +1,50 @@
 # OnlineStatusLight
-.Net app that controls two (green and red) Sonoff switch lights to show online status
+.NET app that controls a lighting service to show online status of Microsoft Teams
 
-- Current implementation for MS Teams check the Status by reading the local logs file.
+=> Current implementation for MS Teams which checks the Status by reading the local logs file.
+```
+"msteams": {
+    "interval": 5,
+    "logfile": "%appdata%\\Microsoft\\Teams\\logs.txt"
+}
+```
+Currently, there are two services supported: [Sonoff](#sonoff) and [Razer](#razer).
+
+## Sonoff
 - Red light turns on for Busy.
-- Green light turns of for Available.
-- Both lights turn on for Do Not Disturb (Presenting). Initial idea was to blink the red light but the switch makes a noise every time is activated, I had to give up that idea.
+- Green light turns on for Available.
+- Both lights turn on for Do Not Disturb (Presenting). Initial idea was to blink the red light but the switch makes a noise every time it is activated so I had to give up that idea.
+
+Use this service by stating in appsettings.json or by omitting it completely:
+```
+"lightservice": "OnlineStatusLight.Application.SonoffBasicR3Service, OnlineStatusLight.Application"
+```
+Additional config:
+```
+"sonoff": {
+    "red": {
+      "ip": "192.168.0.62"
+    },
+    "green": {
+      "ip": "192.168.0.61"
+    }
+}
+```
+
+## Razer
+- Red light turns on for Busy and Do Not Disturb (Presenting).
+- Green light turns on for Available.
+- Yellow light turns on for Away
+- Purple light turns on for OutOfOffice
+
+Use this service by stating in appsettings.json:
+```
+"lightservice": "OnlineStatusLight.Application.Razer.RazerLightService, OnlineStatusLight.Application.Razer"
+```
+Additional config:
+```
+"razer": {
+    // true = will color the HeadSet device only. false = will color ALL Razer devices
+    "headsetonly": true
+}
+```


### PR DESCRIPTION
Added Razer light service by:
- Creating another project "OnlineStatusLight.Application.Razer.RazerLightService"
- Refactoring to ILightService (RazerLightService and SonoffBasicR3Service implement this)

Place the switch in appsettings.json
```
// for Razer
"lightservice": "OnlineStatusLight.Application.Razer.RazerLightService, OnlineStatusLight.Application.Razer"

// for Sonoff (default)
"lightservice": "OnlineStatusLight.Application.SonoffBasicR3Service, OnlineStatusLight.Application"
```

Razer has a config to only light up the headset instead of all devices
```
"razer": {
    // true = will color the HeadSet device only. false = will color ALL Razer devices
    "headsetonly": true
}
```