### PR TITLE
New status + tray icon text update

### DIFF
--- a/OnlineStatusLight.Application.Razer/RazerLightService.cs
+++ b/OnlineStatusLight.Application.Razer/RazerLightService.cs
@@ -40,6 +40,7 @@ namespace OnlineStatusLight.Application.Razer
                     break;
                 case MicrosoftTeamsStatus.Busy:
                 case MicrosoftTeamsStatus.DoNotDisturb:
+                case MicrosoftTeamsStatus.InAMeeting:
                     await SetTargetedDeviceColor(Colore.Data.Color.Red);
                     break;
                 default:

--- a/OnlineStatusLight.Application/MicrosoftTeamsService.cs
+++ b/OnlineStatusLight.Application/MicrosoftTeamsService.cs
@@ -74,6 +74,9 @@ namespace OnlineStatusLight.Application
                                         // ignore this - happens where there is a new activity: Message, Like/Action, File Upload
                                         // this is not a real status change, just shows the bell in the icon
                                         break;
+                                    case "InAMeeting":
+                                        newStatus = MicrosoftTeamsStatus.InAMeeting;
+                                        break;
                                     default:
                                         _logger.LogWarning($"MS Teams status unknown: {status}");
                                         newStatus = MicrosoftTeamsStatus.Unknown;

--- a/OnlineStatusLight.Application/SyncLightService.cs
+++ b/OnlineStatusLight.Application/SyncLightService.cs
@@ -11,6 +11,8 @@ namespace OnlineStatusLight.Application
 
         private Timer _timer;
 
+        public event EventHandler<MicrosoftTeamsStatus> StateChanged; 
+
         public SyncLightService(
             IMicrosoftTeamsService microsoftTeamsService, 
             ILightService lightService)
@@ -22,6 +24,7 @@ namespace OnlineStatusLight.Application
         public async Task Sync()
         {
             var status = _microsoftTeamsService.GetCurrentStatus();
+            StateChanged?.Invoke(this, status);
             await _lightService.SetState(status);
         }
 

--- a/OnlineStatusLight.Core/Models/MicrosoftTeamsStatus.cs
+++ b/OnlineStatusLight.Core/Models/MicrosoftTeamsStatus.cs
@@ -9,6 +9,7 @@
         Away,
         Offline,
         Unknown,
-        OutOfOffice
+        OutOfOffice,
+        InAMeeting
     }
 }

--- a/OnlineStatusLight.Forms/OnlineStatusLightContext.cs
+++ b/OnlineStatusLight.Forms/OnlineStatusLightContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using OnlineStatusLight.Application;
+using OnlineStatusLight.Core.Models;
 using OnlineStatusLight.Forms.Properties;
 using System.ComponentModel;
 using app = System.Windows.Forms;
@@ -11,10 +12,12 @@ namespace OnlineStatusLight.Forms
         private readonly NotifyIcon _notifyIcon;
         private readonly ContextMenuStrip _contextMenu;
         private readonly ToolStripMenuItem _menuItem;
+        private readonly SyncLightService _sync;
         private readonly IContainer _components;
 
-        public OnlineStatusLightContext()
+        public OnlineStatusLightContext(SyncLightService sync)
         {
+            this._sync = sync;
             this._components = new Container();
             this._contextMenu = new ContextMenuStrip();
             this._menuItem = new ToolStripMenuItem();
@@ -45,6 +48,13 @@ namespace OnlineStatusLight.Forms
 
             // Handle the DoubleClick event to activate the form.
             // _notifyIcon.DoubleClick += new EventHandler(this.NotifyIcon_DoubleClick);
+
+            _sync.StateChanged += StateChanged;
+        }
+
+        private void StateChanged(object? sender, MicrosoftTeamsStatus status)
+        {
+            _notifyIcon.Text = $"{Resources.AppName} ({status})";
         }
 
         protected override void Dispose(bool disposing)
@@ -79,8 +89,6 @@ namespace OnlineStatusLight.Forms
         {
             // Hide tray icon, otherwise it will remain shown until user mouses over it
             _notifyIcon.Visible = false;
-
-            var _sync = Startup.AppHost.Services.GetRequiredService<SyncLightService>();
             _sync.Dispose();
 
             app.Application.Exit();

--- a/OnlineStatusLight.Forms/Program.cs
+++ b/OnlineStatusLight.Forms/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Hosting;
 using NLog;
+using OnlineStatusLight.Application;
 using app = System.Windows.Forms;
 
 namespace OnlineStatusLight.Forms
@@ -14,8 +15,8 @@ namespace OnlineStatusLight.Forms
 
             Startup.AppHost = host;
             Startup.SetupErrorLogger();
-
-            app.Application.Run(new OnlineStatusLightContext());
+            var service = Startup.AppHost.Services.GetService(typeof(SyncLightService)) as SyncLightService;
+            app.Application.Run(new OnlineStatusLightContext(service));
 
             LogManager.Flush();
         }

--- a/OnlineStatusLight.Forms/Startup.cs
+++ b/OnlineStatusLight.Forms/Startup.cs
@@ -24,14 +24,14 @@ namespace OnlineStatusLight.Forms
                     ConfigurationRoot = new ConfigurationBuilder()
                         .AddJsonFile(Path.GetFullPath("appsettings.json"), true, true)
                         .Build();
-
+                        
                     var lightService = Type.GetType(ConfigurationRoot!["lightservice"]) ?? typeof(SonoffBasicR3Service);
                     // configure services
                     services
                         .AddSingleton(typeof(ILightService), lightService)
                         .AddSingleton<IMicrosoftTeamsService, MicrosoftTeamsService>()
                         .AddSingleton<SyncLightService>()
-                        .AddHostedService<SyncLightService>();
+                        .AddHostedService<SyncLightService>(p => p.GetRequiredService<SyncLightService>());
 
                     // configure logger
                     services

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Additional config:
 ```
 
 ## Razer
-- Red light turns on for Busy and Do Not Disturb (Presenting).
+- Red light turns on for Busy, In a meeting and Do Not Disturb (Presenting).
 - Green light turns on for Available.
 - Yellow light turns on for Away
 - Purple light turns on for OutOfOffice


### PR DESCRIPTION
This PR will...

...add the features:
- add a new state called InAMeeting (red color for Razer, ignore for Sonoff)
- show the detected state in the tray icon as (text)

...fix: 
SyncLightService was instantiated twice so far. Once for SingletonService and once for HostedService. HostedService is now reusing the SingletonService by providing a constructor function `AddHostedService<SyncLightService>(p => p.GetRequiredService<SyncLightService>());`
